### PR TITLE
Implement ip address setting in store and hook

### DIFF
--- a/examples/network/IpEditor.jsx
+++ b/examples/network/IpEditor.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { useNetwork } from './useNetwork.js';
+
+export function IpEditor() {
+  const { currentNetworkInterface, ipAddress, setIpAddress, lastError } = useNetwork();
+  const [newIp, setNewIp] = useState(ipAddress || '');
+
+  return (
+    <div>
+      <div>Current IF: {currentNetworkInterface || '—'}</div>
+      <div>Current IP: {ipAddress || '—'}</div>
+
+      <input
+        type="text"
+        value={newIp}
+        onChange={(e) => setNewIp(e.target.value)}
+        placeholder="Enter new IP"
+      />
+      <button onClick={() => setIpAddress(currentNetworkInterface, newIp)}>
+        Save
+      </button>
+
+      {lastError && (
+        <div style={{ color: 'red' }}>Error: {lastError.message}</div>
+      )}
+    </div>
+  );
+}
+

--- a/examples/network/network.service.js
+++ b/examples/network/network.service.js
@@ -1,0 +1,44 @@
+// network.service.js
+// Minimal service wrapper — only fine-grained events, no snapshots.
+
+export class NetworkService {
+  constructor({ thunder } = {}) {
+    this.thunder = thunder; // inject Thunder client if available
+    this._listeners = new Set();
+  }
+
+  subscribe(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
+  }
+
+  _emit(evt) {
+    for (const fn of this._listeners) fn(evt);
+  }
+
+  async start() {
+    // Example: subscribe to Thunder's "online" event
+    // this.thunder.on('NetworkOnlineChanged', (online) => {
+    //   this._emit({ type: 'STATUS', isConnectedToInternet: !!online });
+    // });
+  }
+
+  async setIpAddress(name, ip) {
+    try {
+      // Call Thunder API here (pseudo)
+      // await this.thunder.call('Network', 'setIpAddress', { interface: name, ipAddress: ip });
+
+      // On success emit event
+      this._emit({ type: 'IP_CHANGED', name, ip });
+    } catch (err) {
+      this._emit({
+        type: 'ERROR',
+        op: 'setIpAddress',
+        code: err.code || 'E_SET_IP',
+        message: String(err.message || err),
+      });
+      throw err;
+    }
+  }
+}
+

--- a/examples/network/network.store.js
+++ b/examples/network/network.store.js
@@ -1,0 +1,59 @@
+// network.store.js
+import { create } from 'zustand';
+import { NetworkService } from './network.service.js';
+
+const service = new NetworkService();
+
+export const useNetworkStore = create((set, get) => ({
+  ipAddress: null,
+  currentNetworkInterface: null,
+  isConnectedToInternet: false,
+  lastError: null,
+  _started: false,
+
+  start: async () => {
+    if (get()._started) return;
+    set({ _started: true });
+
+    service.subscribe((evt) => {
+      switch (evt.type) {
+        case 'IP_CHANGED':
+          set({
+            ipAddress: evt.ip,
+            currentNetworkInterface: evt.name,
+          });
+          break;
+        case 'STATUS':
+          set({ isConnectedToInternet: !!evt.isConnectedToInternet });
+          break;
+        case 'ERROR':
+          set({
+            lastError: { op: evt.op, code: evt.code, message: evt.message },
+          });
+          break;
+      }
+    });
+
+    await service.start();
+  },
+
+  // Store action (implementation)
+  setIpAddress: async (name, ip) => {
+    // Optional optimistic update
+    set({
+      ipAddress: ip,
+      currentNetworkInterface: name,
+      lastError: null,
+    });
+
+    try {
+      await service.setIpAddress(name, ip);
+      // On success, service emits IP_CHANGED, store updates consistently
+    } catch (e) {
+      set({
+        lastError: { op: 'setIpAddress', code: e.code, message: e.message },
+      });
+    }
+  },
+}));
+

--- a/examples/network/package.json
+++ b/examples/network/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "network-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2"
+  }
+}
+

--- a/examples/network/useNetwork.js
+++ b/examples/network/useNetwork.js
@@ -1,0 +1,22 @@
+// useNetwork.js
+import { useNetworkStore } from './network.store.js';
+
+export function useNetwork() {
+  // Selectors for state
+  const ipAddress = useNetworkStore((s) => s.ipAddress);
+  const currentNetworkInterface = useNetworkStore((s) => s.currentNetworkInterface);
+  const isConnectedToInternet = useNetworkStore((s) => s.isConnectedToInternet);
+  const lastError = useNetworkStore((s) => s.lastError);
+
+  // Expose store actions
+  const setIpAddress = useNetworkStore((s) => s.setIpAddress);
+
+  return {
+    ipAddress,
+    currentNetworkInterface,
+    isConnectedToInternet,
+    lastError,
+    setIpAddress, // pass-through action
+  };
+}
+


### PR DESCRIPTION
Add a network example demonstrating a service, Zustand store, and React hook for managing network state and actions, including an optimistic `setIpAddress` update.

---
<a href="https://cursor.com/background-agent?bcId=bc-df1c3d26-10f3-4d44-9779-107ea64f4039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df1c3d26-10f3-4d44-9779-107ea64f4039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

